### PR TITLE
Grid-cost Names

### DIFF
--- a/inputs/scenarios.yaml
+++ b/inputs/scenarios.yaml
@@ -10,14 +10,15 @@
 
 scenarios:
 - battery: default_battery  # Name of the battery, must be in `inputs/storage`
-  fractional_grid_cost_change: 0.0  # Fractional change to the grid price
+  fractional_grid_cost_change: 0.0  # Fractional change to the grid cost
+  fractional_hw_tank_cost_change: 0.0  # Fractional change to the hw tank cost
   fractional_pv_cost_change: 0.0  # Fractional change to the PV cost
   fractional_pvt_cost_change: 0.0  # Fractional change to the PV-T cost
   fractional_st_cost_change: 0.0  # Fractional change to the solar-thermal cost
   grid_cost_scheme: uae  # Gives the name of the grid cost scheme
   heat_exchanger_efficiency: 0.4  # System efficiency, 0-1
   heat_pump: ammonia  # Name of the heat pump
-  hot_water_tank: hot_water_tank  # Name of the hot-water tank
+  hot_water_tank: grant_hpmono_ind150  # Name of the hot-water tank
   htf_heat_capacity: 4182.0  # [J/kgK]
   inverter_cost: 148.5  # [USD/kW]
   inverter_lifetime: 13  # [years]

--- a/inputs/scenarios.yaml
+++ b/inputs/scenarios.yaml
@@ -14,7 +14,6 @@ scenarios:
   fractional_pv_cost_change: 0.0  # Fractional change to the PV cost
   fractional_pvt_cost_change: 0.0  # Fractional change to the PV-T cost
   fractional_st_cost_change: 0.0  # Fractional change to the solar-thermal cost
-  grid_cost: 0.1
   grid_cost_scheme: uae  # Gives the name of the grid cost scheme
   heat_exchanger_efficiency: 0.4  # System efficiency, 0-1
   heat_pump: ammonia  # Name of the heat pump

--- a/inputs/scenarios.yaml
+++ b/inputs/scenarios.yaml
@@ -9,13 +9,13 @@
 ################################################################################
 
 scenarios:
-- battery: default_battery  # Name of the battery, must be in `inputs/storage`
+- battery: lifos_lb_0012  # Name of the battery, must be in `inputs/storage`
   fractional_grid_cost_change: 0.0  # Fractional change to the grid cost
   fractional_hw_tank_cost_change: 0.0  # Fractional change to the hw tank cost
   fractional_pv_cost_change: 0.0  # Fractional change to the PV cost
   fractional_pvt_cost_change: 0.0  # Fractional change to the PV-T cost
   fractional_st_cost_change: 0.0  # Fractional change to the solar-thermal cost
-  grid_cost_scheme: uae  # Gives the name of the grid cost scheme
+  grid_cost_scheme: la_paz_mexico  # Gives the name of the grid cost scheme
   heat_exchanger_efficiency: 0.4  # System efficiency, 0-1
   heat_pump: ammonia  # Name of the heat pump
   hot_water_tank: grant_hpmono_ind150  # Name of the hot-water tank

--- a/inputs/storage.yaml
+++ b/inputs/storage.yaml
@@ -9,7 +9,7 @@
 ################################################################################
 
 batteries:
-  - name: !!str default_battery
+  - name: !!str lifos_lb_0012
     capacity: !!float 153.6  # [kWh]
     c_rate_charging: !!float 0.33  # Charge rate
     c_rate_discharging: !!float 0.33  # Discharge rate
@@ -26,10 +26,10 @@ batteries:
     leakage: !!float 0.000042  # Fractional leakage per hour
     lifetime_loss: !!float 0.2   # Fractional loss over lifetime (0.0 - 1.0)
 hot_water_tanks:
-  - name: !!str hot_water_tank
-    area: !!float 1900  # [m^2]
-    capacity: !!float 30000  # [kg or litres]
-    cost: !!float 4.15  # [USD/litre]
+  - name: !!str grant_hpmono_ind150
+    area: !!float 0.248  # [m^2]
+    capacity: !!float 150  # [kg or litres]
+    cost: !!float 8.35  # [USD/litre]
     cycle_lifetime: !!float 1500  # Expected number of cycles over lifetime
     heat_loss_coefficient: !!float 1.9  # [W/m^2*K]
     leakage: !!float 0  # Fractional leakage per hour

--- a/plotter.py
+++ b/plotter.py
@@ -2549,10 +2549,48 @@ with open(os.path.join("inputs", "cheap_pv_t_grid_optimisations.json"), "w") as 
 # Plotting collector performance information #
 ##############################################
 
-plt.scatter([entry[(THERMAL_PERFORMANCE_CURVE:="thermal_performance_curve")][(ZEROTH_ORDER:="zeroth_order")] for entry in fpc_data], [entry[THERMAL_PERFORMANCE_CURVE][(FIRST_ORDER:="first_order")] for entry in fpc_data], marker="x", label="flat-plate")
-plt.scatter([entry[(THERMAL_PERFORMANCE_CURVE:="thermal_performance_curve")][(ZEROTH_ORDER:="zeroth_order")] for entry in etc_data], [entry[THERMAL_PERFORMANCE_CURVE][(FIRST_ORDER:="first_order")] for entry in etc_data], marker="x", label="evacuated-tube")
-plt.scatter(mean_fpc[THERMAL_PERFORMANCE_CURVE][ZEROTH_ORDER], mean_fpc[THERMAL_PERFORMANCE_CURVE][FIRST_ORDER], marker="o", color="C0", label="mean flat-plate")
-plt.scatter(mean_etc[THERMAL_PERFORMANCE_CURVE][ZEROTH_ORDER], mean_etc[THERMAL_PERFORMANCE_CURVE][FIRST_ORDER], marker="o", color="C1", label="mean evacuated-tube")
+plt.scatter(
+    [
+        entry[(THERMAL_PERFORMANCE_CURVE := "thermal_performance_curve")][
+            (ZEROTH_ORDER := "zeroth_order")
+        ]
+        for entry in fpc_data
+    ],
+    [
+        entry[THERMAL_PERFORMANCE_CURVE][(FIRST_ORDER := "first_order")]
+        for entry in fpc_data
+    ],
+    marker="x",
+    label="flat-plate",
+)
+plt.scatter(
+    [
+        entry[(THERMAL_PERFORMANCE_CURVE := "thermal_performance_curve")][
+            (ZEROTH_ORDER := "zeroth_order")
+        ]
+        for entry in etc_data
+    ],
+    [
+        entry[THERMAL_PERFORMANCE_CURVE][(FIRST_ORDER := "first_order")]
+        for entry in etc_data
+    ],
+    marker="x",
+    label="evacuated-tube",
+)
+plt.scatter(
+    mean_fpc[THERMAL_PERFORMANCE_CURVE][ZEROTH_ORDER],
+    mean_fpc[THERMAL_PERFORMANCE_CURVE][FIRST_ORDER],
+    marker="o",
+    color="C0",
+    label="mean flat-plate",
+)
+plt.scatter(
+    mean_etc[THERMAL_PERFORMANCE_CURVE][ZEROTH_ORDER],
+    mean_etc[THERMAL_PERFORMANCE_CURVE][FIRST_ORDER],
+    marker="o",
+    color="C1",
+    label="mean evacuated-tube",
+)
 plt.legend()
 plt.xlabel("Zeroth-order performance curve coefficient")
 plt.ylabel("First-order performance curve coefficient")

--- a/src/heatdesalination/__utils__.py
+++ b/src/heatdesalination/__utils__.py
@@ -295,6 +295,12 @@ class GridCostScheme(enum.Enum):
     """
     Denotes the grid-cost scheme used.
 
+    - ABU_DHABI_UAE:
+        The tiered pricing structure used in the emirate of Abu Dhabi in the UAE.
+
+    - DUBAI_UAE:
+        The tiered pricing structure used in the emirate of Dubai in the UAE.
+
     - GRAN_CANARIA_SPAIN:
         The grid pricing structure used on Gran Canaria, Spain.
 
@@ -304,15 +310,13 @@ class GridCostScheme(enum.Enum):
     - TIJUANA:
         The grid pricing structure used in Tijuana, Mexico.
 
-    - UAE:
-        The tiered pricing structure used in the UAE.
-
     """
 
+    ABU_DHABI_UAE: str = "abu_dhabi_uae"
+    DUBAI_UAE: str = "dubai_uae"
     GRAN_CANARIA_SPAIN: str = "gran_canaria"
     LA_PAZ_MEXICO: str = "la_paz_mexico"
     TIJUANA_MEXICO: str = "tijuana_mexico"
-    UAE: str = "uae"
 
 
 @dataclasses.dataclass

--- a/src/heatdesalination/__utils__.py
+++ b/src/heatdesalination/__utils__.py
@@ -188,6 +188,30 @@ class CostableComponent:
         self.cost = cost
 
 
+class CostType(enum.Enum):
+    """
+    Denotes the part of the system which is contributing to the total cost.
+
+    - COMPONENTS:
+        The grid pricing structure used on Gran Canaria, Spain.
+
+    - GRID:
+        The grid pricing structure used in La Paz, Mexico.
+
+    - HEAT_PUMP:
+        The grid pricing structure used in Tijuana, Mexico.
+
+    - INVERTERS:
+        The tiered pricing structure used in the UAE.
+
+    """
+
+    COMPONENTS: str = "components"
+    GRID: str = "grid"
+    HEAT_PUMP: str = "heat_pump"
+    INVERTERS: str = "inverters"
+
+
 def get_logger(
     logger_name: str, hpc: bool = False, verbose: bool = False
 ) -> logging.Logger:
@@ -265,6 +289,30 @@ class FlowRateError(Exception):
         """
 
         super().__init__(f"Flow-rate mismatch for collector '{collector_name}': {msg}")
+
+
+class GridCostScheme(enum.Enum):
+    """
+    Denotes the grid-cost scheme used.
+
+    - GRAN_CANARIA_SPAIN:
+        The grid pricing structure used on Gran Canaria, Spain.
+
+    - LA_PAZ_MEXICO:
+        The grid pricing structure used in La Paz, Mexico.
+
+    - TIJUANA:
+        The grid pricing structure used in Tijuana, Mexico.
+
+    - UAE:
+        The tiered pricing structure used in the UAE.
+
+    """
+
+    GRAN_CANARIA_SPAIN: str = "gran_canaria"
+    LA_PAZ_MEXICO: str = "la_paz_mexico"
+    TIJUANA_MEXICO: str = "tijuana_mexico"
+    UAE: str = "uae"
 
 
 @dataclasses.dataclass
@@ -808,9 +856,8 @@ class Scenario:
     .. attribute:: battery
         The name of the battery.
 
-    .. attribute:: grid_cost
-        The cost of grid electricity (i.e., alternative or unmet electricity) in USD per
-        kWh/
+    .. attribute:: grid_cost_scheme
+        The name of the grid-cost scheme to use.
 
     .. attribute:: heat_exchanger_efficiency
         The efficiency of the heat exchanger.
@@ -863,7 +910,7 @@ class Scenario:
     """
 
     battery: str
-    grid_cost: float
+    grid_cost_scheme: GridCostScheme
     heat_exchanger_efficiency: float
     heat_pump: str
     hot_water_tank: str

--- a/src/heatdesalination/fileparser.py
+++ b/src/heatdesalination/fileparser.py
@@ -24,6 +24,7 @@ import json
 from .__utils__ import (
     AMBIENT_TEMPERATURE,
     AUTO_GENERATED_FILES_DIRECTORY,
+    GridCostScheme,
     NAME,
     OptimisationParameters,
     ProfileType,
@@ -62,13 +63,14 @@ DESALINATION_PLANT_INPUTS: str = "plants.yaml"
 #   Keyword for desalination plants.
 DESALINATION_PLANTS: str = "desalination_plants"
 
-# FRACTIONAL_GRID_cost_CHANGE:
+# FRACTIONAL_GRID_COST_CHANGE:
 #   The fractional change in the price of grid electricity.
-FRACTIONAL_GRID_cost_CHANGE: str = "fractional_grid_cost_change"
+FRACTIONAL_GRID_COST_CHANGE: str = "FRACTIONAL_GRID_COST_CHANGE"
 
-# GRID_COST:
-#   Keyword for the cost of grid (alternative/unmet) electricity.
-GRID_COST: str = "grid_cost"
+# GRID_COST_SCHEME:
+#   Keyword for the name of the pricing scheme for the cost of grid (alternative/unmet)
+# electricity.
+GRID_COST_SCHEME: str = "grid_cost_scheme"
 
 # HEAT_EXCHANGER_EFFICIENCY:
 #   Keyword for parsing the heat capacity of the heat exchangers.
@@ -225,7 +227,7 @@ def parse_input_files(
     scenarios = [
         Scenario(
             entry[BATTERY],
-            entry[GRID_COST],
+            GridCostScheme(entry[GRID_COST_SCHEME]),
             entry[HEAT_EXCHANGER_EFFICIENCY],
             entry[HEAT_PUMP],
             entry[HOT_WATER_TANK],
@@ -238,7 +240,7 @@ def parse_input_files(
             entry[PV],
             entry[PV_T],
             entry[SOLAR_THERMAL],
-            entry.get(FRACTIONAL_GRID_cost_CHANGE, 0),
+            entry.get(FRACTIONAL_GRID_COST_CHANGE, 0),
         )
         for entry in scenario_inputs[SCENARIOS]
     ]

--- a/src/heatdesalination/optimiser.py
+++ b/src/heatdesalination/optimiser.py
@@ -175,8 +175,10 @@ def _total_grid_cost(
     #     * scenario.grid_cost  # [$/kWh]
     # ) * (1 + fractional_cost_change)
 
-    if scenario.grid_cost_scheme == GridCostScheme.UAE:
-        # UAE-specific code
+    if scenario.grid_cost_scheme == GridCostScheme.DUBAI_UAE:
+        # Dubai, UAE-specific code - a tiered tariff applied based on monthly usage.
+        # The industrial slab tariff is used with an exchange rate to USD applied of
+        # 1 AED to 0.27 USD as fixed due to currency pegging.
         monthly_grid_consumption = sum(
             solution.grid_electricity_supply_profile.values()
         ) * (
@@ -184,22 +186,109 @@ def _total_grid_cost(
         )  # [kWh/month]
         lower_tier_consumption = min(monthly_grid_consumption, 10000)
         upper_tier_consumption = max(monthly_grid_consumption - 10000, 0)
-        total_grid_cost = (
+        return (
             (DAYS_PER_YEAR / days_per_month)  # [months/year]
             * system_lifetime  # [years]
             * (
-                lower_tier_consumption * (0.23 * (1 + fractional_cost_change))
-                + upper_tier_consumption * (0.38 * (1 + fractional_cost_change))
+                lower_tier_consumption * (0.063 * (1 + fractional_cost_change))
+                + upper_tier_consumption * (0.10 * (1 + fractional_cost_change))
             )
         )  # [USD]
-    else:
-        logger.error("Grid cost scheme undefined: %s", scenario.grid_cost_scheme.value)
-        raise InputFileError(
-            os.path.join("inputs", "scenarios.yaml"),
-            f"Grid cost scheme f{scenario.grid_cost_scheme.value} not well defined.",
+
+    # The following schemes use lifetime power consumption, so calculate this
+    grid_lifetime_electricity_consumption = (DAYS_PER_YEAR  # [days/year]
+                * system_lifetime # [years]
+                * sum(
+                solution.grid_electricity_supply_profile.values()
+                ) # [kWh/day]
+    )
+
+    if scenario.grid_cost_scheme == GridCostScheme.ABU_DHABI_UAE:
+        # Abu Dhabi, UAE-specific code - a tiered tariff applied based on monthly usage.
+        # The industrial fixed-rate tariff for <1MW installations is used.
+        return (
+            grid_lifetime_electricity_consumption
+        ) * 0.078  # [USD/kWh]
+
+    if scenario.grid_cost_scheme == GridCostScheme.GRAN_CANARIA_SPAIN:
+        # Gran-Canaria-specific code - a flat tariff per kWh consumed.
+        # Gran Canaria grid-cost information obtained from:
+        # Qiblawey Y, Alassi A, Zain ul Abideen M, Banales S.
+        # Techno-economic assessment of increasing the renewable energy supply in the
+        # Canary Islands: The case of Tenerife and Gran Canaria.
+        # Energy Policy 2022;162:112791.
+        # doi: 10.1016/j.enpol.2022.112791.
+        return (
+            DAYS_PER_YEAR  # [days/year]
+            * system_lifetime # [years]
+            * sum(
+            solution.grid_electricity_supply_profile.values()
+            ) # [kWh/day]
+        ) * 0.1537  # [USD/kWh]
+
+    if scenario.grid_cost_scheme in {GridCostScheme.TIJUANA_MEXICO, GridCostScheme.LA_PAZ_MEXICO}:
+        # Mexico grid costs operate using a tiered structure and three costs:
+        #   - a monthly flat-rate cost for using a grid connection,
+        #   - a specific cost which depends on the amount of electricity used,
+        #   - and a cost based on the peak power consumption.
+        # All these values were obtained from the Comisión Federal de Electricidad.
+        if scenario.grid_cost_scheme == GridCostScheme.TIJUANA_MEXICO:
+            # Tijuana-specific code - a two-tier tariff based on power consumption.
+            if 0 < (peak_power:=max(solution.grid_electricity_supply_profile.values())) <= 25:
+                fixed_monthly_cost: float = 59.85  # [USD/month]
+                power_cost: float = 0  # [USD/kW]
+                specific_electricity_cost: float = 2.466  # [USD/kWh]
+            elif peak_power > 25:
+                fixed_monthly_cost = 598.55
+                power_cost = 499.39
+                specific_electricity_cost = 0.826
+            else:
+                fixed_monthly_cost = 0
+                power_cost = 0
+                specific_electricity_cost = 0
+        elif scenario.grid_cost_scheme == GridCostScheme.LA_PAZ_MEXICO:
+            # La-Paz-specific code - a two-tier tariff based on power consumption.
+            if 0 < (peak_power:=max(solution.grid_electricity_supply_profile.values())) <= 25:
+                fixed_monthly_cost: float = 59.85
+                power_cost: float = 0
+                specific_electricity_cost: float = 3.817
+            elif peak_power > 25:
+                fixed_monthly_cost = 598.55
+                power_cost = 454.36
+                specific_electricity_cost = 2.907
+            else:
+                fixed_monthly_cost = 0
+                power_cost = 0
+                specific_electricity_cost = 0
+        else:
+            logger.error("Grid cost scheme undefined: %s", scenario.grid_cost_scheme.value)
+            raise InputFileError(
+                os.path.join("inputs", "scenarios.yaml"),
+                f"Grid cost scheme f{scenario.grid_cost_scheme.value} not well defined.",
+            )
+
+        # Use the fixed monthly cost along with the electricity specific costs to
+        # determine the total grid cost.
+        total_fixed_monthly_cost = (system_lifetime # [years]
+            * 12 # [months/year]
+            * fixed_monthly_cost # [USD/month]
+        )
+        total_power_cost = (
+            peak_power # [kW]
+            * power_cost # [USD/kW]
+        )
+        total_specific_electricity_cost = (
+            specific_electricity_cost # [USD/kWh]
+            * grid_lifetime_electricity_consumption
         )
 
-    return total_grid_cost
+        return total_fixed_monthly_cost + total_power_cost + total_specific_electricity_cost
+
+    logger.error("Grid cost scheme undefined: %s", scenario.grid_cost_scheme.value)
+    raise InputFileError(
+        os.path.join("inputs", "scenarios.yaml"),
+        f"Grid cost scheme f{scenario.grid_cost_scheme.value} not well defined.",
+    )
 
 
 def _total_cost(

--- a/src/heatdesalination/optimiser.py
+++ b/src/heatdesalination/optimiser.py
@@ -196,19 +196,16 @@ def _total_grid_cost(
         )  # [USD]
 
     # The following schemes use lifetime power consumption, so calculate this
-    grid_lifetime_electricity_consumption = (DAYS_PER_YEAR  # [days/year]
-                * system_lifetime # [years]
-                * sum(
-                solution.grid_electricity_supply_profile.values()
-                ) # [kWh/day]
+    grid_lifetime_electricity_consumption = (
+        DAYS_PER_YEAR  # [days/year]
+        * system_lifetime  # [years]
+        * sum(solution.grid_electricity_supply_profile.values())  # [kWh/day]
     )
 
     if scenario.grid_cost_scheme == GridCostScheme.ABU_DHABI_UAE:
         # Abu Dhabi, UAE-specific code - a tiered tariff applied based on monthly usage.
         # The industrial fixed-rate tariff for <1MW installations is used.
-        return (
-            grid_lifetime_electricity_consumption
-        ) * 0.078  # [USD/kWh]
+        return (grid_lifetime_electricity_consumption) * 0.078  # [USD/kWh]
 
     if scenario.grid_cost_scheme == GridCostScheme.GRAN_CANARIA_SPAIN:
         # Gran-Canaria-specific code - a flat tariff per kWh consumed.
@@ -220,13 +217,14 @@ def _total_grid_cost(
         # doi: 10.1016/j.enpol.2022.112791.
         return (
             DAYS_PER_YEAR  # [days/year]
-            * system_lifetime # [years]
-            * sum(
-            solution.grid_electricity_supply_profile.values()
-            ) # [kWh/day]
+            * system_lifetime  # [years]
+            * sum(solution.grid_electricity_supply_profile.values())  # [kWh/day]
         ) * 0.1537  # [USD/kWh]
 
-    if scenario.grid_cost_scheme in {GridCostScheme.TIJUANA_MEXICO, GridCostScheme.LA_PAZ_MEXICO}:
+    if scenario.grid_cost_scheme in {
+        GridCostScheme.TIJUANA_MEXICO,
+        GridCostScheme.LA_PAZ_MEXICO,
+    }:
         # Mexico grid costs operate using a tiered structure and three costs:
         #   - a monthly flat-rate cost for using a grid connection,
         #   - a specific cost which depends on the amount of electricity used,
@@ -234,7 +232,11 @@ def _total_grid_cost(
         # All these values were obtained from the Comisión Federal de Electricidad.
         if scenario.grid_cost_scheme == GridCostScheme.TIJUANA_MEXICO:
             # Tijuana-specific code - a two-tier tariff based on power consumption.
-            if 0 < (peak_power:=max(solution.grid_electricity_supply_profile.values())) <= 25:
+            if (
+                0
+                < (peak_power := max(solution.grid_electricity_supply_profile.values()))
+                <= 25
+            ):
                 fixed_monthly_cost: float = 59.85  # [USD/month]
                 power_cost: float = 0  # [USD/kW]
                 specific_electricity_cost: float = 2.466  # [USD/kWh]
@@ -248,7 +250,11 @@ def _total_grid_cost(
                 specific_electricity_cost = 0
         elif scenario.grid_cost_scheme == GridCostScheme.LA_PAZ_MEXICO:
             # La-Paz-specific code - a two-tier tariff based on power consumption.
-            if 0 < (peak_power:=max(solution.grid_electricity_supply_profile.values())) <= 25:
+            if (
+                0
+                < (peak_power := max(solution.grid_electricity_supply_profile.values()))
+                <= 25
+            ):
                 fixed_monthly_cost: float = 59.85
                 power_cost: float = 0
                 specific_electricity_cost: float = 3.817
@@ -261,7 +267,9 @@ def _total_grid_cost(
                 power_cost = 0
                 specific_electricity_cost = 0
         else:
-            logger.error("Grid cost scheme undefined: %s", scenario.grid_cost_scheme.value)
+            logger.error(
+                "Grid cost scheme undefined: %s", scenario.grid_cost_scheme.value
+            )
             raise InputFileError(
                 os.path.join("inputs", "scenarios.yaml"),
                 f"Grid cost scheme f{scenario.grid_cost_scheme.value} not well defined.",
@@ -269,20 +277,22 @@ def _total_grid_cost(
 
         # Use the fixed monthly cost along with the electricity specific costs to
         # determine the total grid cost.
-        total_fixed_monthly_cost = (system_lifetime # [years]
-            * 12 # [months/year]
-            * fixed_monthly_cost # [USD/month]
+        total_fixed_monthly_cost = (
+            system_lifetime  # [years]
+            * 12  # [months/year]
+            * fixed_monthly_cost  # [USD/month]
         )
-        total_power_cost = (
-            peak_power # [kW]
-            * power_cost # [USD/kW]
-        )
+        total_power_cost = peak_power * power_cost  # [kW]  # [USD/kW]
         total_specific_electricity_cost = (
-            specific_electricity_cost # [USD/kWh]
+            specific_electricity_cost  # [USD/kWh]
             * grid_lifetime_electricity_consumption
         )
 
-        return total_fixed_monthly_cost + total_power_cost + total_specific_electricity_cost
+        return (
+            total_fixed_monthly_cost
+            + total_power_cost
+            + total_specific_electricity_cost
+        )
 
     logger.error("Grid cost scheme undefined: %s", scenario.grid_cost_scheme.value)
     raise InputFileError(

--- a/src/heatdesalination/plant.py
+++ b/src/heatdesalination/plant.py
@@ -229,12 +229,8 @@ class DesalinationPlant:
 
         try:
             plant_outputs = {
-                True: PlantOutputs(
-                    **input_data[PLANT_OPERATING][OUTPUTS]
-                ),
-                False: PlantOutputs(
-                    **input_data[PLANT_DISABLED][OUTPUTS]
-                ),
+                True: PlantOutputs(**input_data[PLANT_OPERATING][OUTPUTS]),
+                False: PlantOutputs(**input_data[PLANT_DISABLED][OUTPUTS]),
             }
         except KeyError as exception:
             logger.error(

--- a/src/heatdesalination/simulator.py
+++ b/src/heatdesalination/simulator.py
@@ -595,7 +595,9 @@ def _tank_ambient_temperature(ambient_temperature: float) -> float:
     return ambient_temperature
 
 
-def _tank_replacement_temperature(ambient_temperature: float, hot_water_return_temperature: float | None) -> float:
+def _tank_replacement_temperature(
+    ambient_temperature: float, hot_water_return_temperature: float | None
+) -> float:
     """
     Return the temperature of water which is replacing that taken from the tank.
 
@@ -766,7 +768,10 @@ def run_simulation(
             solar_thermal_collector,
             solar_thermal_mass_flow_rate,
             _tank_ambient_temperature(ambient_temperatures[hour]),
-            _tank_replacement_temperature(ambient_temperatures[hour], desalination_plant.outputs(hour).hot_water_return_temperature),
+            _tank_replacement_temperature(
+                ambient_temperatures[hour],
+                desalination_plant.outputs(hour).hot_water_return_temperature,
+            ),
         )
 
         # Determine the electricity demands of the plant including any auxiliary

--- a/src/heatdesalination/solar.py
+++ b/src/heatdesalination/solar.py
@@ -1497,13 +1497,13 @@ class SolarThermalPanel(SolarPanel, panel_type=SolarPanelType.SOLAR_THERMAL):
         # Ensure that the collector has not stagnated.
         if negative_root > self.stagnation_temperature:
             logger.debug(
-                "Collector %s outputted HTF at %s degC, above its stagnation ""temperature of %s degC",
+                "Collector %s outputted HTF at %s degC, above its stagnation "
+                "temperature of %s degC",
                 self.name,
                 negative_root,
-                self.stagnation_temperature
+                self.stagnation_temperature,
             )
             negative_root = self.stagnation_temperature
-
 
         # Compute temperature quantities.
         average_temperature = 0.5 * (negative_root + input_temperature)  # [K]


### PR DESCRIPTION
Grid costs, as mentioned in #4, had to be manually coded for each country to be considered. This is primarily due to different countries having vastly different pricing structures that it is difficult to code for. E.G.,
* Dubai within the UAE operates a tiered pricing structure with two tiers based on monthly electricity consumption,
* Tijuana in Mexico operates a similar two-tier structure, but with tiers based on the total peak power consumption but with additional charges for peak power placed on the system,
* and Abu Dhabi, also within the UAE, operates a single tier for its pricing structure.

To solve this, the countries that are currently being considered as part of any research work have been manually added as different calculations within the `optimiser.py` file. Whilst not ideal, this likely presents the best solution for now.

A longer-term fix may be for individual countries to be defined as python files which contain these particular functions.