### PR TITLE
:bug: Fix electric performance curve inputs

### DIFF
--- a/src/heatdesalination/solar.py
+++ b/src/heatdesalination/solar.py
@@ -954,7 +954,7 @@ class HybridPVTPanel(SolarPanel, panel_type=SolarPanelType.PV_T):
             solar_inputs[NAME],
         )
 
-        self.electric_performance_curve: PerformanceCurve = electric_performance_curve
+        self.electric_performance_curve: PerformanceCurve | None = electric_performance_curve
         self._max_mass_flow_rate = solar_inputs[MAX_MASS_FLOW_RATE]
         self._min_mass_flow_rate = solar_inputs[MIN_MASS_FLOW_RATE]
         self.pv_module_characteristics = pv_module_characteristics
@@ -1077,11 +1077,11 @@ class HybridPVTPanel(SolarPanel, panel_type=SolarPanelType.PV_T):
                     electric_performance_inputs[SECOND_ORDER],
                 )
             except KeyError as exception:
-                logger.error(
+                logger.info(
                     "Missing electric performance curve input(s): %s",
                     str(exception),
                 )
-                raise
+                electric_performance_curve = None
         else:
             electric_performance_curve = None
             logger.debug(
@@ -1102,7 +1102,7 @@ class HybridPVTPanel(SolarPanel, panel_type=SolarPanelType.PV_T):
                 )
             except KeyError as exception:
                 logger.error(
-                    "Missing electric performance curve input(s): %s",
+                    "Missing module characteristics: %s",
                     str(exception),
                 )
                 raise


### PR DESCRIPTION
### Description
This pull request is being opened to address the issue whereby an exception is thrown when an electric performance curve is not provided for PV-T collectors.
This PR resolves issue #11.

No new features are introduced into the program and so this will be merged into the current version, `v1.0.0a1`.

### Linked Issues
This pull request:
* closes 11.

### Unit tests
This pull request does not affect any unit tests.